### PR TITLE
Fix CountDownTimer decrement bug

### DIFF
--- a/Shuffle100/SwiftUI Views/viewModels/MinSec.ViewModel.swift
+++ b/Shuffle100/SwiftUI Views/viewModels/MinSec.ViewModel.swift
@@ -20,7 +20,7 @@ extension MinSec {
     init(startTime: CGFloat, interval: CGFloat) {
       self.startTime = startTime
       self.interval = interval
-      self.timer = CountDownTimer(startTime: startTime, intarval: interval)
+      self.timer = CountDownTimer(startTime: startTime, interval: interval)
       self.timeTexts = timeTexts(of: startTime)
       buildDataFlow()
     }

--- a/Shuffle100/SwiftUI Views/viewModels/viewModels_ToretaStyle/Sec2FViewModel.swift
+++ b/Shuffle100/SwiftUI Views/viewModels/viewModels_ToretaStyle/Sec2FViewModel.swift
@@ -36,7 +36,7 @@ final class Sec2FViewModel: ViewModelObject {
     let input = Input()
     let binding = Binding()
     let output = Output()
-    let timer = CountDownTimer(startTime: startTime, intarval: interval)
+    let timer = CountDownTimer(startTime: startTime, interval: interval)
     output.secText = Self.strOf(time: startTime)
     
     timer.$remainTime

--- a/Shuffle100/models/CountDownTimer.swift
+++ b/Shuffle100/models/CountDownTimer.swift
@@ -13,12 +13,12 @@ class CountDownTimer: ObservableObject {
   @Published private(set) var remainTime: Double
   @Published private(set) var isRunning = false
   
-  private let intarval: Double
+  private let interval: Double
   private var timer: Timer?
   
-  init(startTime remainTime: Double, intarval: Double) {
+  init(startTime remainTime: Double, interval: Double) {
     self.remainTime = remainTime
-    self.intarval = intarval
+    self.interval = interval
   }
   
   deinit {
@@ -27,9 +27,9 @@ class CountDownTimer: ObservableObject {
   }
   
   func start() {
-    timer = Timer.scheduledTimer(withTimeInterval: intarval, repeats: true) { [weak self] _ in
+    timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
       guard let self = self else { return }
-      self.remainTime -= CGFloat(self.intarval)
+      self.remainTime -= self.interval
       if self.isRunning == false {
         self.isRunning = true
       }
@@ -37,13 +37,13 @@ class CountDownTimer: ObservableObject {
       if self.remainTime <= 0 {
         self.isRunning = false
         self.remainTime = 0.0
-        self.stopAneEraseTimer()
+        self.stopAndEraseTimer()
       }
     }
   }
   
   func stop() {
-    stopAneEraseTimer()
+    stopAndEraseTimer()
   }
   
   func reset(to newTime: Double) {
@@ -51,7 +51,7 @@ class CountDownTimer: ObservableObject {
     self.remainTime = newTime
   }
   
-  private func stopAneEraseTimer() {
+  private func stopAndEraseTimer() {
     self.timer?.invalidate()
     self.timer = nil
   }

--- a/Shuffle100Tests/models/CountDownTimerTests.swift
+++ b/Shuffle100Tests/models/CountDownTimerTests.swift
@@ -13,7 +13,7 @@ final class CountDownTimerTests: XCTestCase {
 
     func testInitCountDownTimer() {
         // given
-        let timer = CountDownTimer(startTime: 3.0, intarval: 1.0)
+        let timer = CountDownTimer(startTime: 3.0, interval: 1.0)
         // then
         XCTAssertEqual(timer.remainTime, 3.0)
         XCTAssertFalse(timer.isRunning)
@@ -21,7 +21,7 @@ final class CountDownTimerTests: XCTestCase {
 
     func testRunningCountDownTimer() {
         // given
-        let timer = CountDownTimer(startTime: 3.0, intarval: 1.0)
+        let timer = CountDownTimer(startTime: 3.0, interval: 1.0)
         var cancellables = Set<AnyCancellable>()
         let expectetion = XCTestExpectation(description: "Timer is reducing remain time correctly.")
         // when


### PR DESCRIPTION
## Summary
- rename `intarval` to `interval` for clarity
- fix countdown decrement to subtract a `Double` value
- rename `stopAneEraseTimer` to `stopAndEraseTimer`
- update view models and tests for new initializer

## Testing
- `fastlane scan --skip_build --only_testing Shuffle100Tests --scheme Shuffle100` *(fails: rbenv version `2.7.5` not installed)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6845476c080883298d8f5e198d70d5bc